### PR TITLE
Implement basic WebSocket chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# chat
+# WebRTC Chat
+
+This project provides a simple chat interface styled with Tailwind CSS. It includes mock channels and messages plus a button to toggle voice status. The app runs locally using Node.js and Docker Compose.
+
+## Structure
+
+```
+client/ - React frontend with Tailwind CSS
+server/ - Express + WebSocket backend for chat and signaling
+```
+
+## Quick start
+
+1. **Build and start containers**
+   ```bash
+   docker-compose up --build
+   ```
+2. Open `http://localhost:4000` in your browser.
+3. Use the input at the bottom to send messages. The **Join Voice** button toggles a mock voice status indicator.
+
+The frontend connects to the backend WebSocket on port `4001`.
+
+## Development
+
+- Frontend commands:
+  ```bash
+  cd client
+  npm install
+  npm run dev
+  ```
+- Backend commands:
+  ```bash
+  cd server
+  npm install
+  npm start
+  ```
+
+Tailwind configuration is minimal and can be extended as needed.

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-alpine as build
+WORKDIR /app
+COPY package.json package-lock.json* yarn.lock* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 4000
+CMD ["serve", "-s", "dist", "-l", "4000"]

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebRTC Chat</title>
+    <script type="module" src="/src/main.jsx"></script>
+  </head>
+  <body class="bg-gray-900">
+    <div id="root"></div>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "webrtc-chat-client",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "serve -s dist -l 4000"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.0",
+    "vite": "^4.3.0"
+  }
+}

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState, useRef } from 'react';
+import Sidebar from './components/Sidebar.jsx';
+import ChatWindow from './components/ChatWindow.jsx';
+import MessageInput from './components/MessageInput.jsx';
+import VoiceButton from './components/VoiceButton.jsx';
+
+const initialMessages = {
+  General: [],
+  Random: [],
+};
+
+export default function App() {
+  const [channel, setChannel] = useState('General');
+  const [messages, setMessages] = useState(initialMessages);
+  const [socket, setSocket] = useState(null);
+  const [myId, setMyId] = useState(null);
+  const channelRef = useRef('General');
+
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:4001');
+    ws.onmessage = (event) => {
+      let data = {};
+      try {
+        data = JSON.parse(event.data);
+      } catch (_) {
+        return;
+      }
+
+      if (data.type === 'id') {
+        setMyId(data.id);
+      } else if (data.type === 'chat') {
+        const user = data.from === myId ? 'Me' : `User${data.from}`;
+        setMessages((prev) => {
+          const ch = channelRef.current;
+          return {
+            ...prev,
+            [ch]: [
+              ...(prev[ch] || []),
+              {
+                user,
+                text: data.message,
+                time: new Date().toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                }),
+              },
+            ],
+          };
+        });
+      }
+    };
+    setSocket(ws);
+    return () => ws.close();
+  }, []);
+
+  const addMessage = (text) => {
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: 'chat', message: text }));
+    }
+  };
+
+  return (
+    <div className="h-screen flex bg-gray-900 text-gray-200">
+      <Sidebar
+        channels={Object.keys(messages)}
+        current={channel}
+        setCurrent={(ch) => {
+          channelRef.current = ch;
+          setChannel(ch);
+        }}
+      />
+      <div className="flex-1 flex flex-col">
+        <div className="flex justify-between items-center p-4 border-b border-gray-700">
+          <h1 className="text-xl font-semibold">{channel}</h1>
+          <VoiceButton />
+        </div>
+        <ChatWindow messages={messages[channel]} />
+        <MessageInput onSend={addMessage} />
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ChatWindow.jsx
+++ b/client/src/components/ChatWindow.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function ChatWindow({ messages }) {
+  return (
+    <div className="flex-1 flex flex-col justify-end overflow-y-auto p-4 space-y-2">
+      {messages.map((msg, idx) => (
+        <div key={idx} className="flex items-start space-x-2">
+          <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
+          <div>
+            <div className="text-sm text-gray-400">{msg.user} <span className="ml-1 text-xs">{msg.time}</span></div>
+            <div className="text-gray-200">{msg.text}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/MessageInput.jsx
+++ b/client/src/components/MessageInput.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+export default function MessageInput({ onSend }) {
+  const [value, setValue] = useState('');
+
+  const send = () => {
+    if (value.trim()) {
+      onSend(value.trim());
+      setValue('');
+    }
+  };
+
+  const handleKey = (e) => {
+    if (e.key === 'Enter') {
+      send();
+    }
+  };
+
+  return (
+    <div className="p-4 border-t border-gray-700 bg-gray-800 flex">
+      <input
+        className="flex-1 bg-gray-700 text-gray-200 p-2 rounded focus:outline-none"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyPress={handleKey}
+        placeholder="Message"
+      />
+      <button
+        onClick={send}
+        className="ml-2 px-4 py-2 bg-blue-600 text-white rounded"
+      >
+        Send
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function Sidebar({ channels, current, setCurrent }) {
+  return (
+    <div className="w-48 bg-gray-800 text-gray-200 flex-shrink-0">
+      <h2 className="text-lg font-semibold p-4 border-b border-gray-700">Channels</h2>
+      {channels.map((ch) => (
+        <button
+          key={ch}
+          onClick={() => setCurrent(ch)}
+          className={`w-full text-left px-4 py-2 hover:bg-gray-700 ${current === ch ? 'bg-gray-700' : ''}`}
+        >
+          {ch}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/VoiceButton.jsx
+++ b/client/src/components/VoiceButton.jsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+
+export default function VoiceButton() {
+  const [online, setOnline] = useState(false);
+
+  const toggle = () => {
+    setOnline((prev) => !prev);
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      className={`px-4 py-2 rounded text-white ${online ? 'bg-green-600' : 'bg-red-600'}`}
+    >
+      {online ? 'Voice Online' : 'Join Voice'}
+    </button>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  server:
+    build: ./server
+    ports:
+      - '4001:4001'
+    container_name: webrtc_server
+  client:
+    build: ./client
+    ports:
+      - '4000:4000'
+    depends_on:
+      - server
+    container_name: webrtc_client

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* yarn.lock* ./
+RUN npm install
+COPY . .
+EXPOSE 4001
+CMD ["node", "index.js"]

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const http = require('http');
+const WebSocket = require('ws');
+const cors = require('cors');
+const { handleSignaling } = require('./signaling');
+
+const app = express();
+app.use(cors());
+const server = http.createServer(app);
+const wss = new WebSocket.Server({ server });
+
+let nextId = 1;
+const clients = new Map();
+
+wss.on('connection', (ws) => {
+  const id = nextId++;
+  clients.set(id, ws);
+  ws.send(JSON.stringify({ type: 'id', id }));
+
+  ws.on('message', (message) => {
+    let data = {};
+    try {
+      data = JSON.parse(message.toString());
+    } catch (e) {
+      return;
+    }
+
+    if (data.type === 'chat') {
+      wss.clients.forEach((client) => {
+        if (client.readyState === WebSocket.OPEN) {
+          client.send(
+            JSON.stringify({
+              type: 'chat',
+              message: data.message,
+              from: id,
+            })
+          );
+        }
+      });
+    } else {
+      handleSignaling(data, id, clients);
+    }
+  });
+
+  ws.on('close', () => {
+    clients.delete(id);
+  });
+});
+
+app.get('/', (req, res) => {
+  res.send('WebRTC Chat Server');
+});
+
+server.listen(4001, () => {
+  console.log('Server listening on port 4001');
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "webrtc-chat-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.13.0",
+    "cors": "^2.8.5"
+  }
+}

--- a/server/signaling.js
+++ b/server/signaling.js
@@ -1,0 +1,24 @@
+function handleSignaling(data, senderId, clients) {
+  const target = clients.get(data.to);
+  if (target && target.readyState === 1) {
+    target.send(
+      JSON.stringify({
+        type: data.type,
+        from: senderId,
+        to: data.to,
+        offer: data.offer,
+        answer: data.answer,
+        candidate: data.candidate,
+      })
+    );
+  }
+  if (data.type === 'join-voice') {
+    clients.forEach((client, id) => {
+      if (id !== senderId && client.readyState === 1) {
+        client.send(JSON.stringify({ type: 'new-user', id: senderId }));
+      }
+    });
+  }
+}
+
+module.exports = { handleSignaling };


### PR DESCRIPTION
## Summary
- fix Vite entry by renaming index.html and main file
- connect to the WebSocket server and render chat messages
- include sender id with each chat broadcast

## Testing
- `npm install` in `client`
- `npm run build` in `client`
- `npm install` in `server`
- `node -v`
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f6bbf0dc08330b56be7c494a5cebb