### PR TITLE
feat: add call dialog stub and store

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,6 @@
 
 import { useState } from 'react';
+import Channel from './channel';
 
 function App() {
   const [messages, setMessages] = useState([]);
@@ -19,7 +20,7 @@ function App() {
           <li className="text-blue-400"># general</li>
           <li># random</li>
         </ul>
-        <button className="mt-6 bg-blue-600 px-4 py-2 rounded">Join Voice</button>
+        <Channel />
       </aside>
       <main className="flex-1 flex flex-col">
         <div className="flex-1 p-4 overflow-y-auto">

--- a/client/src/channel.tsx
+++ b/client/src/channel.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { useCallStore } from './store/calls';
+
+function Channel() {
+  const { addCall } = useCallStore();
+  const [open, setOpen] = useState(false);
+
+  const callClickHandler = () => {
+    addCall({ id: Date.now(), with: 'stub-user' });
+    setOpen(true);
+  };
+
+  return (
+    <div>
+      <button onClick={callClickHandler} className="mt-6 bg-blue-600 px-4 py-2 rounded">
+        Join Voice
+      </button>
+      {open && (
+        <div className="mt-4 p-4 bg-gray-800 rounded">
+          <p>Call dialog placeholder</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Channel;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,9 +3,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { CallProvider } from './store/calls';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <CallProvider>
+      <App />
+    </CallProvider>
   </React.StrictMode>
 );

--- a/client/src/store/calls.ts
+++ b/client/src/store/calls.ts
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+interface Call {
+  id: number;
+  with: string;
+}
+
+interface CallStore {
+  calls: Call[];
+  addCall: (call: Call) => void;
+}
+
+const CallContext = createContext<CallStore | undefined>(undefined);
+
+export const CallProvider = ({ children }: { children: ReactNode }) => {
+  const [calls, setCalls] = useState<Call[]>([]);
+  const addCall = (call: Call) => setCalls((prev) => [...prev, call]);
+  return <CallContext.Provider value={{ calls, addCall }}>{children}</CallContext.Provider>;
+};
+
+export const useCallStore = () => {
+  const context = useContext(CallContext);
+  if (!context) {
+    throw new Error('useCallStore must be used within a CallProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- add channel component with call dialog placeholder
- track calls in a simple React context store
- wrap app with call provider and use channel component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68981d2c3db88330a70c627ee8147ab4